### PR TITLE
Fix check for attributes named "Nothing"

### DIFF
--- a/includes/nft_creator.py
+++ b/includes/nft_creator.py
@@ -180,7 +180,7 @@ class NftCreator:
             attributes_count = 0
             filteredAttributes = []
             for i in range(len(attributes)):
-                if items[i][dna[i]] != "Notrait":
+                if items[i][dna[i]] != "Nothing":
                     attributes_count += 1
                     filteredAttributes.append({attributes[i]: items[i][dna[i]]})
                     nftAttributes.append({"trait_type": attributes[i], "value":items[i][dna[i]]})


### PR DESCRIPTION
When creating an NFT and creating its attributes, you were checking for name "Notrait" to skip those blank attributes and avoiding they appear into the dictionary.
In your input folder you are using layers named "Nothing" or "nothing".

I haven't checked but maybe also READMI file need to be updated