### PR TITLE
Fix to the typo in the readme for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Finally, we generate a **json file containing all the information of the rarity 
 To start creating ur uniques NFTs for Solana you will have to ***clone*** **our github repository**. Open your terminal and execute the followings commands:
 1. `git clone https://github.com/Solseum/solseum-nft-generator.git`
 2. `cd solseum-nft-generator`
-3. `python3 -m pip install -r requiriments.txt`
+3. `python3 -m pip install -r requirements.txt`
 
 
 ### Step 3: Be one with the folders!


### PR DESCRIPTION
Been using solseum for a while, it slightly irks me everytime I copy the install command and have to fix the typo.

Figured I'd fix it.